### PR TITLE
fix(discovery): change how CancelledError from asyncio is accessed

### DIFF
--- a/axon/discovery.py
+++ b/axon/discovery.py
@@ -62,7 +62,7 @@ async def broadcast_discovery(node_type='*', port=comms_config.worker_port, num_
 		try:	
 			await all_reqs
 
-		except(asyncio.exceptions.CancelledError):
+		except(asyncio.CancelledError):
 			pass
 
 	return result_holder['result']


### PR DESCRIPTION
On Python 3.7, the `asyncio` module doesn't have an `exceptions` property,
which results in the underlying error from being displayed in the error
message properly. It seems the `CancelledError` property can
be accessed directly through the `asyncio` module directly on python
versions 3.7+.

Here's an example of a relevant error message that's shown without the change:

```
$ python src/worker.py   
Traceback (most recent call last):
  File "/home/bryan/.local/share/virtualenvs/mthe-493-group-a2-e9HO8nW2/lib/python3.7/site-packages/axon/discovery.py", line 63, in broadcast_discovery
    await all_reqs
concurrent.futures._base.CancelledError

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "src/worker.py", line 155, in <module>
    asyncio.run(main())
  File "/home/bryan/.asdf/installs/python/3.7.12/lib/python3.7/asyncio/runners.py", line 43, in run
    return loop.run_until_complete(main)
  File "/home/bryan/.asdf/installs/python/3.7.12/lib/python3.7/asyncio/base_events.py", line 587, in run_until_complete
    return future.result()
  File "src/worker.py", line 142, in main
    axon_local_ips = await discovery.broadcast_discovery(num_hosts=1, port=config.comms_config.notice_board_port)
  File "/home/bryan/.local/share/virtualenvs/mthe-493-group-a2-e9HO8nW2/lib/python3.7/site-packages/axon/discovery.py", line 65, in broadcast_discovery
    except(asyncio.exceptions.CancelledError):
AttributeError: module 'asyncio' has no attribute 'exceptions'
```

Testing locally with Python 3.7 confirms that the error doesn't come up again, letting the subsequent `pass` statement do its job.